### PR TITLE
Implement proper generation of zig types in their extern form

### DIFF
--- a/example/sysjs_generated.zig
+++ b/example/sysjs_generated.zig
@@ -3,15 +3,15 @@
 const builtin = @import("builtin");
 
 pub const console = struct {
-    extern fn sysjs_console_log(string: []const u8) void;
-    extern fn sysjs_console_log2(string: []const u8, []const u8) void;
+    extern fn sysjs_console_log(string: [*]const u8, string_len: u32) void;
+    extern fn sysjs_console_log2(string: [*]const u8, string_len: u32, [*]const u8, u32) void;
 
     pub inline fn log(string: []const u8) void {
-        return sysjs_console_log(string);
+        return sysjs_console_log(string.ptr, string.len);
     }
 
     pub inline fn log2(string: []const u8, v1: []const u8) void {
-        return sysjs_console_log2(string, v1);
+        return sysjs_console_log2(string.ptr, string.len, v1.ptr, v1.len);
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -252,18 +252,18 @@ fn Generator(comptime ZigWriter: type, comptime JSWriter: type) type {
         // Emits parameters for functions, but in their 'extern' form.
         // e.g. expanding `[]const u8` to a pointer and length or such.
         fn externParam(gen: *@This(), param_name: ?[]const u8, type_index: Ast.Node.Index) !void {
-            const tags = gen.tree.tokens.items(.tag);
-
             var i: Ast.Node.Index = undefined;
             const state = gen.typeState(type_index, &i);
 
-            const is_const = tags[i + 1] == .keyword_const;
-            const js_type = gen.tree.tokenSlice(i + 2); // TODO: convert zig types to js types
+            const token_starts = gen.tree.tokens.items(.start);
+
+            const last_token = gen.tree.lastToken(type_index);
+            const end = token_starts[last_token] + gen.tree.tokenSlice(last_token).len;
+            const js_type = gen.tree.source[token_starts[i + 1]..end];
 
             if (state == .slice) {
                 try printParamName(gen.zig, param_name, null);
-                try std.fmt.format(gen.zig, "[*]{s}{s}, ", .{
-                    if (is_const) "const " else " ",
+                try std.fmt.format(gen.zig, "[*]{s}, ", .{
                     js_type,
                 });
 


### PR DESCRIPTION
Types like slices will now be generated as pair of its pointer and its length. This behavior is implemented for both arguments (function calls) as well as parameters (function declarations).
